### PR TITLE
Don't add slug if the slug attribute has no value

### DIFF
--- a/lib/slugworth.rb
+++ b/lib/slugworth.rb
@@ -5,7 +5,7 @@ module Slugworth
 
   included do
     cattr_accessor :slug_attribute, :slug_scope, :slug_incremental, :slug_updatable
-    before_validation(:add_slug)
+    before_validation(:add_slug, if: :slug_attribute_value)
   end
 
   module ClassMethods
@@ -38,12 +38,16 @@ module Slugworth
     !slug.present? || slug_updatable && changes[slug_attribute].present?
   end
 
+  def slug_attribute_value
+    public_send(slug_attribute)
+  end
+
   def processed_slug
     slug_incremental ? process_incremental_slug : parameterized_slug
   end
 
   def parameterized_slug
-    public_send(slug_attribute).parameterize
+    slug_attribute_value.parameterize
   end
 
   def process_incremental_slug

--- a/lib/slugworth_shared_examples.rb
+++ b/lib/slugworth_shared_examples.rb
@@ -1,10 +1,16 @@
 shared_examples_for :has_slug_functionality do
   describe "#slug" do
     context "when no slug is set" do
-      specify 'slug is generated' do
+      specify 'slug is generated with slug attribute' do
         obj = described_class.new(described_class.slug_attribute => 'Generated slug')
         obj.valid?
         expect(obj.slug).to eq('generated-slug')
+      end
+
+      specify 'slug is not generated with no slug attribute' do
+        obj = described_class.new
+        obj.valid?
+        expect(obj.slug).to be_nil
       end
     end
 


### PR DESCRIPTION
If the slug attribute that Slugworth is trying to generate a slug from is nil, Slugworth throws an `Undefined method parameterize on nil:NilClass`

Example:

You have a `User` class that has a username attribute.

You've included Slugworth and it relies on the username attribute to generate slugs. Like: 

```
class User
  include Slugworth 
  slugged_with :username
end
```

You new up a user object, and you call valid on it: `User.new.valid?`

That's when you'll get the nil error, because Slugworth is trying to generate a slug on an attribute that is nil.

We've added a guard against this.